### PR TITLE
CI Update

### DIFF
--- a/.github/workflows/ubuntu_focal.yml
+++ b/.github/workflows/ubuntu_focal.yml
@@ -13,7 +13,7 @@ jobs:
     name: Ubuntu-Focal
     runs-on: ubuntu-latest
     env:
-      PROJECT_DIR: src/${{ github.event.repository.name }}
+      PROJECT_DIR: src/plugin_loader
     steps:
       - name: Prepare workspace
         working-directory: ..
@@ -27,15 +27,13 @@ jobs:
       - name: Install dependencies
         working-directory: ../..
         run: |
-          pwd
-          ls
           sudo apt update -q
           sudo apt install -q -y clang-tidy python3 python3-pip
           sudo pip3 install -q --upgrade pip
           sudo pip3 install -q colcon-common-extensions rosdep vcstool
           sudo rosdep init -q
           rosdep update -q
-          vcs import src < src/${{ github.event.repository.name }}/dependencies.repos
+          vcs import src < ${{ env.PROJECT_DIR }}/dependencies.repos
           rosdep install --from-paths src --ignore-src -r -y -q
 
       - name: Build


### PR DESCRIPTION
The [webhook payload for events triggered on schedule is empty](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule), so CI can't extract the project name using `github.event.repository.name` for scheduled builds. This PR replaces that name with a hard-coded string instead